### PR TITLE
Add middle-click handling to calendar UI

### DIFF
--- a/src/ui/Calendar.svelte
+++ b/src/ui/Calendar.svelte
@@ -25,7 +25,7 @@
   export let onClickMonth: (date: Moment, isMetaPressed: boolean) => boolean;
   export let onClickYear: (date: Moment, isMetaPressed: boolean) => boolean;
   export let onClickQuarter: (date: Moment, isMetaPressed: boolean) => boolean;
-  export let onClickToday: (date: Moment) => void;
+  export let onClickToday: (date: Moment, inNewLeaf: boolean) => void;
 
   export let onContextMenuDay: (date: Moment, event: MouseEvent) => boolean;
   export let onContextMenuWeek: (date: Moment, event: MouseEvent) => boolean;

--- a/src/ui/calendar-ui/components/Calendar.svelte
+++ b/src/ui/calendar-ui/components/Calendar.svelte
@@ -43,7 +43,9 @@
   export let onClickMonth: (date: Moment, isMetaPressed: boolean) => boolean;
   export let onClickYear: (date: Moment, isMetaPressed: boolean) => boolean;
   export let onClickQuarter: (date: Moment, isMetaPressed: boolean) => boolean;
-  export let onClickToday: ((date: Moment) => void) | undefined = undefined;
+  export let onClickToday:
+    | ((date: Moment, inNewLeaf: boolean) => void)
+    | undefined = undefined;
   export let showTodayButtonOnMobile: boolean = false;
   // External sources (All optional)
   export let sources: ICalendarSource[] = [];

--- a/src/ui/calendar-ui/components/Day.svelte
+++ b/src/ui/calendar-ui/components/Day.svelte
@@ -7,7 +7,7 @@
   import Dot from "./Dot.svelte";
   import MetadataResolver from "./MetadataResolver.svelte";
   import type { IDayMetadata } from "../types";
-  import { isMetaPressed, isWeekend } from "../utils";
+  import { isMetaPressed, isMiddleClick, isWeekend } from "../utils";
 
   // Properties
   export let date: Moment;
@@ -37,6 +37,14 @@
       class:adjacent-month="{!date.isSame(displayedMonth, 'month')}"
       class:today="{date.isSame(today, 'day')}"
       on:click="{onClick && ((e) => onClick(date, isMetaPressed(e)))}"
+      on:auxclick="{onClick &&
+        ((e) => {
+          if (isMiddleClick(e)) {
+            e.preventDefault();
+            onClick(date, true);
+          }
+        })}"
+      on:mousedown="{(e) => isMiddleClick(e) && e.preventDefault()}"
       on:contextmenu="{onContextMenu && ((e) => onContextMenu(date, e))}"
       on:pointerover="{onHover &&
         ((e) => onHover(date, e.target, isMetaPressed(e)))}"

--- a/src/ui/calendar-ui/components/Nav.svelte
+++ b/src/ui/calendar-ui/components/Nav.svelte
@@ -2,7 +2,7 @@
   import type { Moment } from "src/types/moment";
   import { Platform } from "obsidian";
   import Arrow from "./Arrow.svelte";
-  import { isMetaPressed } from "../utils";
+  import { isMetaPressed, isMiddleClick } from "../utils";
   export let displayedMonth: Moment;
   export let today: Moment;
   export let resetDisplayedMonth: () => void;
@@ -15,7 +15,9 @@
   // Optional Today-click callback. When provided, the Today button jumps to
   // the current month *and* invokes this with `today` so the parent can open
   // or create today's daily note via the same path day-cell clicks use.
-  export let onClickToday: ((date: Moment) => void) | undefined = undefined;
+  export let onClickToday:
+    | ((date: Moment, inNewLeaf: boolean) => void)
+    | undefined = undefined;
   // Mobile-only opt-in: render the Today button in the mobile header. Off
   // by default to keep the mobile header uncrowded. Desktop always shows
   // the Today button regardless of this prop.
@@ -43,13 +45,29 @@
         class="month"
         on:click="{(event) => {
           onClickMonth(displayedMonth, isMetaPressed(event));
-        }}">{displayedMonth.format("MMM")}</span
+        }}"
+        on:auxclick="{(event) => {
+          if (isMiddleClick(event)) {
+            event.preventDefault();
+            onClickMonth(displayedMonth, true);
+          }
+        }}"
+        on:mousedown="{(event) => isMiddleClick(event) && event.preventDefault()}"
+        >{displayedMonth.format("MMM")}</span
       >
       <span
         class="year"
         on:click="{(event) => {
           onClickYear(displayedMonth, isMetaPressed(event));
-        }}">{displayedMonth.format("YYYY")}</span
+        }}"
+        on:auxclick="{(event) => {
+          if (isMiddleClick(event)) {
+            event.preventDefault();
+            onClickYear(displayedMonth, true);
+          }
+        }}"
+        on:mousedown="{(event) => isMiddleClick(event) && event.preventDefault()}"
+        >{displayedMonth.format("YYYY")}</span
       >
     </h3>
     {#if quarterVisible}
@@ -62,7 +80,19 @@
               onClickQuarter(
                 getStartOfQuarter(displayedMonth.year(), quarter),
                 isMetaPressed(event),
-              )}">Q{quarter}</span
+              )}"
+            on:auxclick="{(event) => {
+              if (isMiddleClick(event)) {
+                event.preventDefault();
+                onClickQuarter(
+                  getStartOfQuarter(displayedMonth.year(), quarter),
+                  true,
+                );
+              }
+            }}"
+            on:mousedown="{(event) =>
+              isMiddleClick(event) && event.preventDefault()}"
+            >Q{quarter}</span
           >
           {#if index < 3}
             <span class="divider">•</span>
@@ -82,8 +112,16 @@
         class="reset-button"
         on:click="{() => {
           resetDisplayedMonth();
-          onClickToday?.(today);
+          onClickToday?.(today, false);
         }}"
+        on:auxclick="{(event) => {
+          if (isMiddleClick(event)) {
+            event.preventDefault();
+            resetDisplayedMonth();
+            onClickToday?.(today, true);
+          }
+        }}"
+        on:mousedown="{(event) => isMiddleClick(event) && event.preventDefault()}"
       >
         {todayDisplayStr}
       </div>

--- a/src/ui/calendar-ui/components/WeekNum.svelte
+++ b/src/ui/calendar-ui/components/WeekNum.svelte
@@ -7,7 +7,7 @@
   import Dot from "./Dot.svelte";
   import MetadataResolver from "./MetadataResolver.svelte";
   import type { IDayMetadata } from "../types";
-  import { getStartOfWeek, isMetaPressed } from "../utils";
+  import { getStartOfWeek, isMetaPressed, isMiddleClick } from "../utils";
 
   // Properties
   export let weekNum: number;
@@ -37,6 +37,14 @@
       class="{`week-num ${metadata.classes.join(' ')}`}"
       class:active="{selectedId === getDateUID(days[0], 'weekly')}"
       on:click="{onClick && ((e) => onClick(startOfWeek, isMetaPressed(e)))}"
+      on:auxclick="{onClick &&
+        ((e) => {
+          if (isMiddleClick(e)) {
+            e.preventDefault();
+            onClick(startOfWeek, true);
+          }
+        })}"
+      on:mousedown="{(e) => isMiddleClick(e) && e.preventDefault()}"
       on:contextmenu="{onContextMenu && ((e) => onContextMenu(days[0], e))}"
       on:pointerover="{onHover &&
         ((e) => onHover(startOfWeek, e.target, isMetaPressed(e)))}"

--- a/src/ui/calendar-ui/utils.ts
+++ b/src/ui/calendar-ui/utils.ts
@@ -9,6 +9,10 @@ export function isMetaPressed(e: MouseEvent): boolean {
   return Platform.isMacOS ? e.metaKey : e.ctrlKey;
 }
 
+export function isMiddleClick(e: MouseEvent): boolean {
+  return e.button === 1;
+}
+
 export function getDaysOfWeek(..._args: unknown[]): string[] {
   return moment.weekdaysShort(true);
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -406,10 +406,9 @@ export default class CalendarView extends ItemView {
 
   // Today button: jump to the current month (handled by the Calendar
   // component) and, if daily notes are enabled, open or create today's
-  // daily note via the same path day-cell clicks use. Plain pane —
-  // modifier state isn't passed from the Today control.
-  onClickToday = (date: Moment): void => {
-    void this.openOrCreateDailyNote(date, false);
+  // daily note via the same path day-cell clicks use.
+  onClickToday = (date: Moment, inNewLeaf: boolean): void => {
+    void this.openOrCreateDailyNote(date, inNewLeaf);
   };
 
   openOrCreateWeeklyNote = async (


### PR DESCRIPTION
Hi Matt, thanks for your work updating this plugin!

This PR adds middle-click support to open notes in a new tab/split (follows the user's configured option).

I had wanted to do this under https://github.com/liamcain/obsidian-calendar-plugin/pull/331, but found it was more trouble than it was worth with a separately maintained Calendar UI package - so I appreciate the merge you've done with that dependency.

Also resolves #3 